### PR TITLE
Add english-spanish translation for magic cards

### DIFF
--- a/apps/web/app.vue
+++ b/apps/web/app.vue
@@ -1,4 +1,6 @@
 <template>
+  <VueQueryDevtools />
+
   <div>
     <AppHeader />
     <main class="container mx-auto p-4">
@@ -9,6 +11,7 @@
 
 <script setup lang="ts">
 import { createClient } from "@supabase/supabase-js";
+import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import AppHeader from "./components/AppHeader.vue";
 
 const config = useRuntimeConfig();

--- a/apps/web/components/AppHeader.vue
+++ b/apps/web/components/AppHeader.vue
@@ -70,6 +70,7 @@ const links = computed(() =>
   [
     { to: "/", text: t("home") },
     user.value ? { to: "/quizzes", text: t("quizzes") } : null,
+    { to: "/magic-quiz", text: "Magic Quiz" },
     { to: "/about", text: t("about") },
     !user.value ? { to: "/register", text: t("register") } : null,
   ].filter(Boolean)

--- a/apps/web/components/magic-cards/CardImage.vue
+++ b/apps/web/components/magic-cards/CardImage.vue
@@ -3,8 +3,9 @@
     <div
       v-if="imageLoading"
       class="w-full rounded mb-4 h-[400px] bg-gray-200 dark:bg-gray-700 animate-pulse"
-    />
+    ></div>
     <img
+      v-show="!imageLoading"
       :src="imageUrl"
       :alt="altText"
       class="w-full rounded mb-4 h-[400px] object-contain"

--- a/apps/web/components/magic-cards/CardImage.vue
+++ b/apps/web/components/magic-cards/CardImage.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <div
+      v-if="imageLoading"
+      class="w-full rounded mb-4 h-[400px] bg-gray-200 dark:bg-gray-700 animate-pulse"
+    />
+    <img
+      :src="imageUrl"
+      :alt="altText"
+      class="w-full rounded mb-4 h-[400px] object-contain"
+      @load="handleImageLoad"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+interface Props {
+  imageUrl?: string;
+  altText: string;
+}
+
+const props = defineProps<Props>();
+const imageLoading = ref(true);
+
+const handleImageLoad = () => {
+  imageLoading.value = false;
+};
+
+watch(
+  () => props.imageUrl,
+  (newVal, oldVal) => {
+    if (newVal !== oldVal) {
+      imageLoading.value = true;
+    }
+  }
+);
+</script>

--- a/apps/web/composables/scryfall.ts
+++ b/apps/web/composables/scryfall.ts
@@ -1,0 +1,34 @@
+// apps/web/composables/scryfall.ts
+
+class Http {
+  async fetch<T>(url: string | URL): Promise<T> {
+    const response = await fetch(url.toString());
+    if (!response.ok) throw new Error("Network error");
+    return response.json();
+  }
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class ScryfallApiHttp extends Http {
+  private rateLimitPromise = Promise.resolve();
+
+  async fetch<T>(url: string | URL) {
+    await this.rateLimitPromise;
+    const response = super.fetch<T>(url);
+    this.rateLimitPromise = response.then(() => wait(50)).catch(() => wait(50));
+    return response;
+  }
+}
+
+export class ScryfallApi {
+  constructor(private readonly http: Http = new ScryfallApiHttp()) {}
+
+  async getRandomCard(query: string) {
+    const url = new URL("https://api.scryfall.com/cards/random");
+    url.searchParams.set("q", query);
+    return this.http.fetch(url);
+  }
+}
+
+export const ScryfallApiInstance = new ScryfallApi();

--- a/apps/web/composables/useMagicCards.ts
+++ b/apps/web/composables/useMagicCards.ts
@@ -23,24 +23,49 @@ interface CardResponse {
 
 export const useMagicCards = () => {
   const getRandomCard = async (): Promise<CardResponse> => {
-    // 1. Fetch a random MH3 card in English
-    const english = (await ScryfallApiInstance.getRandomCard(
-      "set:mh3"
-    )) as Card;
-    // 2. Fetch the Spanish version by name
-    const searchUrl = new URL("https://api.scryfall.com/cards/search");
-    searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
-    const searchRes = await fetch(searchUrl.toString()).then((res) =>
-      res.json()
-    );
-    const spanish =
-      searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
-    return { english, spanish };
+    try {
+      // 1. Fetch a random MH3 card in English
+      const english = (await ScryfallApiInstance.getRandomCard(
+        "set:mh3"
+      )) as Card;
+
+      if (!english) {
+        throw new Error("Failed to fetch English card");
+      }
+
+      console.log("Fetched English card:", english.name);
+
+      // 2. Fetch the Spanish version by name
+      const searchUrl = new URL("https://api.scryfall.com/cards/search");
+      searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
+
+      const searchRes = await fetch(searchUrl.toString()).then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch Spanish card: ${res.statusText}`);
+        }
+        return res.json();
+      });
+
+      const spanish =
+        searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
+
+      if (spanish) {
+        console.log("Fetched Spanish card:", spanish.name);
+      } else {
+        console.warn("No Spanish translation found for:", english.name);
+      }
+
+      return { english, spanish };
+    } catch (error) {
+      console.error("Error fetching cards:", error);
+      throw error; // Re-throw to let Vue Query handle it
+    }
   };
 
-  const { data, refetch, isFetching } = useQuery({
+  const { data, refetch, isFetching, error } = useQuery({
     queryKey: ["random-mh3-card"],
     queryFn: getRandomCard,
+    retry: 1, // Only retry once on failure
   });
 
   const card = computed(() => data.value?.english);
@@ -51,5 +76,6 @@ export const useMagicCards = () => {
     cardEs,
     refetch,
     isFetching,
+    error,
   };
 };

--- a/apps/web/composables/useMagicCards.ts
+++ b/apps/web/composables/useMagicCards.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/vue-query";
+import { computed } from "vue";
+import { ScryfallApiInstance } from "./scryfall";
+
+interface CardImage {
+  normal: string;
+}
+
+interface Card {
+  name: string;
+  type_line: string;
+  oracle_text: string;
+  image_uris?: CardImage;
+  printed_name?: string;
+  printed_type_line?: string;
+  printed_text?: string;
+}
+
+interface CardResponse {
+  english: Card;
+  spanish: Card | null;
+}
+
+export const useMagicCards = () => {
+  const getRandomCard = async (): Promise<CardResponse> => {
+    // 1. Fetch a random MH3 card in English
+    const english = (await ScryfallApiInstance.getRandomCard(
+      "set:mh3"
+    )) as Card;
+    // 2. Fetch the Spanish version by name
+    const searchUrl = new URL("https://api.scryfall.com/cards/search");
+    searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
+    const searchRes = await fetch(searchUrl.toString()).then((res) =>
+      res.json()
+    );
+    const spanish =
+      searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
+    return { english, spanish };
+  };
+
+  const { data, refetch, isFetching } = useQuery({
+    queryKey: ["random-mh3-card"],
+    queryFn: getRandomCard,
+  });
+
+  const card = computed(() => data.value?.english);
+  const cardEs = computed(() => data.value?.spanish);
+
+  return {
+    card,
+    cardEs,
+    refetch,
+    isFetching,
+  };
+};

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,6 +1,8 @@
 // @ts-check
-import withNuxt from './.nuxt/eslint.config.mjs'
+import withNuxt from "./.nuxt/eslint.config.mjs";
 
-export default withNuxt(
-  // Your custom configs here
-)
+export default withNuxt({
+  rules: {
+    "vue/html-self-closing": "off",
+  },
+});

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
     { path: "~/components", pathPrefix: false },
     { path: "~/components/ui", pathPrefix: false },
   ],
-  plugins: ["~/plugins/theme.client.ts"],
+  plugins: ["~/plugins/theme.client.ts", "~/plugins/vue-query.ts"],
   runtimeConfig: {
     public: {
       supabaseUrl: process.env.SUPABASE_URL,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,8 @@
     "@primevue/nuxt-module": "^4.3.4",
     "eslint": "^9.26.0",
     "typescript": "^5.8.2",
+    "@tanstack/vue-query-devtools": "^5.76.0",
+    "@vue/devtools-api": "7.7.6",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@primeuix/themes": "^1.1.1",
     "@supabase/supabase-js": "^2.49.4",
     "@tailwindcss/vite": "^4.1.5",
+    "@tanstack/vue-query": "^5.76.0",
     "@vueuse/core": "^13.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -88,29 +88,11 @@
 </template>
 
 <script setup lang="ts">
-import { useQuery } from "@tanstack/vue-query";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import CardImage from "~/components/magic-cards/CardImage.vue";
-import { ScryfallApiInstance } from "~/composables/scryfall";
+import { useMagicCards } from "~/composables/useMagicCards";
 
-interface CardImage {
-  normal: string;
-}
-
-interface Card {
-  name: string;
-  type_line: string;
-  oracle_text: string;
-  image_uris?: CardImage;
-  printed_name?: string;
-  printed_type_line?: string;
-  printed_text?: string;
-}
-
-interface CardResponse {
-  english: Card;
-  spanish: Card | null;
-}
+const { card, cardEs, refetch, isFetching } = useMagicCards();
 
 const isEnglishCovered = ref(false);
 const isSpanishCovered = ref(false);
@@ -122,24 +104,4 @@ const toggleEnglishOverlay = () => {
 const toggleSpanishOverlay = () => {
   isSpanishCovered.value = !isSpanishCovered.value;
 };
-
-const getRandomCard = async (): Promise<CardResponse> => {
-  // 1. Fetch a random MH3 card in English
-  const english = (await ScryfallApiInstance.getRandomCard("set:mh3")) as Card;
-  // 2. Fetch the Spanish version by name
-  const searchUrl = new URL("https://api.scryfall.com/cards/search");
-  searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
-  const searchRes = await fetch(searchUrl.toString()).then((res) => res.json());
-  const spanish =
-    searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
-  return { english, spanish };
-};
-
-const { data, refetch, isFetching } = useQuery({
-  queryKey: ["random-mh3-card"],
-  queryFn: getRandomCard,
-});
-
-const card = computed(() => data.value?.english);
-const cardEs = computed(() => data.value?.spanish);
 </script>

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold mb-8 text-gray-900 dark:text-white">
+      Magic: The Gathering Random MH3 Card (EN & ES)
+    </h1>
+    <div class="mb-6">
+      <button
+        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        :disabled="isFetching"
+        @click="refetch"
+      >
+        <span v-if="isFetching">Loading...</span>
+        <span v-else>Get Random Card</span>
+      </button>
+    </div>
+    <div class="mb-4 flex space-x-4">
+      <button
+        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        @click="toggleEnglishOverlay"
+      >
+        {{ isEnglishCovered ? "Show English" : "Hide English" }}
+      </button>
+      <button
+        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        @click="toggleSpanishOverlay"
+      >
+        {{ isSpanishCovered ? "Show Spanish" : "Hide Spanish" }}
+      </button>
+    </div>
+    <div
+      v-if="card && cardEs"
+      class="grid md:grid-cols-2 gap-4 max-w-[800px] mx-auto"
+    >
+      <!-- English Card -->
+      <div
+        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
+      >
+        <img
+          v-if="card.image_uris?.normal"
+          :src="card.image_uris.normal"
+          :alt="card.name"
+          class="w-full rounded mb-4"
+        />
+        <div
+          v-if="isEnglishCovered"
+          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+        >
+          <span class="text-white text-xl">Covered</span>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
+          {{ card.name }}
+        </h2>
+        <p class="text-gray-700 dark:text-gray-300 mb-2">
+          {{ card.type_line }}
+        </p>
+        <p class="text-gray-500 dark:text-gray-400">{{ card.oracle_text }}</p>
+      </div>
+      <!-- Spanish Card -->
+      <div
+        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
+      >
+        <img
+          v-if="cardEs.image_uris?.normal"
+          :src="cardEs.image_uris.normal"
+          :alt="cardEs.name"
+          class="w-full rounded mb-4"
+        />
+        <div
+          v-if="isSpanishCovered"
+          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+        >
+          <span class="text-white text-xl">Covered</span>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
+          {{ cardEs.printed_name || cardEs.name }}
+        </h2>
+        <p class="text-gray-700 dark:text-gray-300 mb-2">
+          {{ cardEs.printed_type_line || cardEs.type_line }}
+        </p>
+        <p class="text-gray-500 dark:text-gray-400">
+          {{ cardEs.printed_text || cardEs.oracle_text }}
+        </p>
+      </div>
+    </div>
+    <div
+      v-else-if="isFetching"
+      class="text-center text-gray-500 dark:text-gray-400"
+    >
+      Loading...
+    </div>
+    <div v-else class="text-center text-gray-500 dark:text-gray-400">
+      Click the button to get a random card!
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useQuery } from "@tanstack/vue-query";
+import { computed, ref } from "vue";
+import { ScryfallApiInstance } from "~/composables/scryfall";
+
+const isEnglishCovered = ref(true);
+const isSpanishCovered = ref(false);
+
+const toggleEnglishOverlay = () => {
+  isEnglishCovered.value = !isEnglishCovered.value;
+};
+
+const toggleSpanishOverlay = () => {
+  isSpanishCovered.value = !isSpanishCovered.value;
+};
+
+const getRandomCard = async () => {
+  // 1. Fetch a random MH3 card in English
+  const english = await ScryfallApiInstance.getRandomCard("set:mh3");
+  // 2. Fetch the Spanish version by name
+  const searchUrl = new URL("https://api.scryfall.com/cards/search");
+  searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
+  const searchRes = await fetch(searchUrl.toString()).then((res) => res.json());
+  const spanish =
+    searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
+  return { english, spanish };
+};
+
+const { data, refetch, isFetching } = useQuery({
+  queryKey: ["random-mh3-card"],
+  queryFn: getRandomCard,
+  enabled: false,
+});
+
+const card = computed(() => data.value?.english);
+const cardEs = computed(() => data.value?.spanish);
+</script>

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -28,6 +28,19 @@
       </button>
     </div>
     <div
+      v-if="error"
+      class="max-w-[800px] mx-auto mb-4 p-4 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100 rounded-lg"
+    >
+      <p class="font-semibold">Error loading cards:</p>
+      <p>{{ error.message }}</p>
+      <button
+        class="mt-2 px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        @click="() => refetch()"
+      >
+        Try Again
+      </button>
+    </div>
+    <div
       v-if="card && cardEs"
       class="grid md:grid-cols-2 gap-4 max-w-[800px] mx-auto"
     >
@@ -92,7 +105,7 @@ import { ref } from "vue";
 import CardImage from "~/components/magic-cards/CardImage.vue";
 import { useMagicCards } from "~/composables/useMagicCards";
 
-const { card, cardEs, refetch, isFetching } = useMagicCards();
+const { card, cardEs, refetch, isFetching, error } = useMagicCards();
 
 const isEnglishCovered = ref(false);
 const isSpanishCovered = ref(false);

--- a/apps/web/plugins/vue-query.ts
+++ b/apps/web/plugins/vue-query.ts
@@ -1,0 +1,6 @@
+import { defineNuxtPlugin } from "#app";
+import { VueQueryPlugin } from "@tanstack/vue-query";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(VueQueryPlugin);
+});

--- a/apps/web/plugins/vue-query.ts
+++ b/apps/web/plugins/vue-query.ts
@@ -1,8 +1,22 @@
 import { defineNuxtPlugin } from "#app";
-import { VueQueryPlugin } from "@tanstack/vue-query";
+import {
+  VueQueryPlugin,
+  type VueQueryPluginOptions,
+} from "@tanstack/vue-query";
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(VueQueryPlugin, {
-    enableDevtoolsV6Plugin: true,
-  });
+  const options: VueQueryPluginOptions = {
+    enableDevtoolsV6Plugin: process.env.NODE_ENV !== "production",
+    queryClientConfig: {
+      defaultOptions: {
+        queries: {
+          staleTime: 5 * 60 * 1000, // 5 minutes
+          retry: 1,
+          refetchOnWindowFocus: false,
+        },
+      },
+    },
+  };
+
+  nuxtApp.vueApp.use(VueQueryPlugin, options);
 });

--- a/apps/web/plugins/vue-query.ts
+++ b/apps/web/plugins/vue-query.ts
@@ -2,5 +2,7 @@ import { defineNuxtPlugin } from "#app";
 import { VueQueryPlugin } from "@tanstack/vue-query";
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(VueQueryPlugin);
+  nuxtApp.vueApp.use(VueQueryPlugin, {
+    enableDevtoolsV6Plugin: true,
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,12 @@ importers:
       '@primevue/nuxt-module':
         specifier: ^4.3.4
         version: 4.3.4(@babel/parser@7.27.2)(magicast@0.3.5)(vue@3.5.13(typescript@5.8.3))
+      '@tanstack/vue-query-devtools':
+        specifier: ^5.76.0
+        version: 5.76.0(@tanstack/vue-query@5.76.0(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
+      '@vue/devtools-api':
+        specifier: 7.7.6
+        version: 7.7.6
       eslint:
         specifier: ^9.26.0
         version: 9.26.0(jiti@2.4.2)
@@ -1598,12 +1604,21 @@ packages:
   '@tanstack/query-core@5.76.0':
     resolution: {integrity: sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==}
 
+  '@tanstack/query-devtools@5.76.0':
+    resolution: {integrity: sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==}
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.13.8':
     resolution: {integrity: sha512-BT6w89Hqy7YKaWewYzmecXQzcJh6HTBbKYJIIkMaNU49DZ06LoTV3z32DWWEdUsgW6n1xTmwTLs4GtWrZC261w==}
+
+  '@tanstack/vue-query-devtools@5.76.0':
+    resolution: {integrity: sha512-5+AlC3gXDWV1SnxHOFfdUp4pL2SkypUGdDnAYOhZbubjqRrTvOtsCwqwvHJG/ohNmDayoZakjZ4dPcgbBI8oPA==}
+    peerDependencies:
+      '@tanstack/vue-query': ^5.76.0
+      vue: ^3.3.0
 
   '@tanstack/vue-query@5.76.0':
     resolution: {integrity: sha512-Ow1JPfAqjam/hH2WJj15Y+a7FT5LS/So2b4jMAI3lLKUcpIjVRLEOLQXdCYZ/29YbDrL66trwLPXjA9tYrHung==}
@@ -7825,9 +7840,17 @@ snapshots:
 
   '@tanstack/query-core@5.76.0': {}
 
+  '@tanstack/query-devtools@5.76.0': {}
+
   '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.13.8': {}
+
+  '@tanstack/vue-query-devtools@5.76.0(@tanstack/vue-query@5.76.0(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@tanstack/query-devtools': 5.76.0
+      '@tanstack/vue-query': 5.76.0(vue@3.5.13(typescript@5.8.3))
+      vue: 3.5.13(typescript@5.8.3)
 
   '@tanstack/vue-query@5.76.0(vue@3.5.13(typescript@5.8.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.5
         version: 4.1.5(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      '@tanstack/vue-query':
+        specifier: ^5.76.0
+        version: 5.76.0(vue@3.5.13(typescript@5.8.3))
       '@vueuse/core':
         specifier: ^13.2.0
         version: 13.2.0(vue@3.5.13(typescript@5.8.3))
@@ -1588,12 +1591,28 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
+    engines: {node: '>=12'}
+
+  '@tanstack/query-core@5.76.0':
+    resolution: {integrity: sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==}
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.13.8':
     resolution: {integrity: sha512-BT6w89Hqy7YKaWewYzmecXQzcJh6HTBbKYJIIkMaNU49DZ06LoTV3z32DWWEdUsgW6n1xTmwTLs4GtWrZC261w==}
+
+  '@tanstack/vue-query@5.76.0':
+    resolution: {integrity: sha512-Ow1JPfAqjam/hH2WJj15Y+a7FT5LS/So2b4jMAI3lLKUcpIjVRLEOLQXdCYZ/29YbDrL66trwLPXjA9tYrHung==}
+    peerDependencies:
+      '@vue/composition-api': ^1.1.2
+      vue: ^2.6.0 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@tanstack/vue-table@8.21.3':
     resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
@@ -4736,6 +4755,9 @@ packages:
     peerDependencies:
       vue: '>= 3.2.0'
 
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
@@ -7797,9 +7819,23 @@ snapshots:
       tailwindcss: 4.1.5
       vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    dependencies:
+      remove-accents: 0.5.0
+
+  '@tanstack/query-core@5.76.0': {}
+
   '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.13.8': {}
+
+  '@tanstack/vue-query@5.76.0(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.19.4
+      '@tanstack/query-core': 5.76.0
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.8.3)
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.8.3))
 
   '@tanstack/vue-table@8.21.3(vue@3.5.13(typescript@5.8.3))':
     dependencies:
@@ -11367,6 +11403,8 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
+
+  remove-accents@0.5.0: {}
 
   remove-trailing-separator@1.1.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Magic: The Gathering quiz page displaying random cards from the "mh3" set in English and Spanish with interactive overlays.
  - Added a "Get Random Card" button to fetch and display new card pairs.
  - Added a card image component with loading placeholders for smoother image rendering.
  - Integrated Scryfall API client with built-in rate limiting for fetching random cards.
  - Added a new navigation link to access the Magic Quiz page from the app header.
- **Enhancements**
  - Integrated Vue Query for efficient, reactive data fetching with Vue Query Devtools enabled for improved debugging.
- **Chores**
  - Added @tanstack/vue-query and related devtools dependencies.
  - Registered Vue Query plugin and devtools in the Nuxt application setup.
  - Disabled the "vue/html-self-closing" ESLint rule for improved code style flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->