### PR TITLE
Add forms to select which set and language

### DIFF
--- a/apps/web/components/magic-cards/CardForm.vue
+++ b/apps/web/components/magic-cards/CardForm.vue
@@ -1,0 +1,78 @@
+<template>
+  <FormKit type="form" :actions="false" class="mb-6" @submit="handleSubmit">
+    <div class="grid md:grid-cols-2 gap-4">
+      <FormKit
+        type="select"
+        name="language"
+        label="Card Language"
+        :options="[
+          { label: 'English', value: 'en' },
+          { label: 'Spanish', value: 'es' },
+          { label: 'Japanese', value: 'ja' },
+          { label: 'French', value: 'fr' },
+          { label: 'German', value: 'de' },
+          { label: 'Italian', value: 'it' },
+          { label: 'Portuguese', value: 'pt' },
+          { label: 'Russian', value: 'ru' },
+          { label: 'Korean', value: 'ko' },
+          { label: 'Chinese Simplified', value: 'zhs' },
+          { label: 'Chinese Traditional', value: 'zht' },
+        ]"
+        validation="required"
+        validation-label="Language"
+        :value="modelValue.language"
+        @input="updateValue('language', $event)"
+      />
+
+      <FormKit
+        type="select"
+        name="set"
+        label="Card Set"
+        :options="[
+          { label: 'Modern Horizons 3', value: 'mh3' },
+          { label: 'Murders at Karlov Manor', value: 'mkm' },
+          { label: 'The Lost Caverns of Ixalan', value: 'lci' },
+          { label: 'Wilds of Eldraine', value: 'woe' },
+          { label: 'March of the Machine', value: 'mom' },
+          { label: 'Phyrexia: All Will Be One', value: 'one' },
+          { label: 'The Brothers\' War', value: 'bro' },
+          { label: 'Dominaria United', value: 'dmu' },
+        ]"
+        validation="required"
+        validation-label="Set"
+        :value="modelValue.set"
+        @input="updateValue('set', $event)"
+      />
+    </div>
+  </FormKit>
+</template>
+
+<script setup lang="ts">
+interface CardFormData {
+  language: string;
+  set: string;
+}
+
+interface Props {
+  modelValue: CardFormData;
+}
+
+interface Emits {
+  (e: "update:modelValue", value: CardFormData): void;
+  (e: "submit", value: CardFormData): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<Emits>();
+
+const updateValue = (key: keyof CardFormData, value: string) => {
+  emit("update:modelValue", {
+    ...props.modelValue,
+    [key]: value,
+  });
+};
+
+const handleSubmit = (formData: CardFormData) => {
+  emit("submit", formData);
+};
+</script>

--- a/apps/web/components/magic-cards/CardForm.vue
+++ b/apps/web/components/magic-cards/CardForm.vue
@@ -5,74 +5,94 @@
         type="select"
         name="language"
         label="Card Language"
-        :options="[
-          { label: 'English', value: 'en' },
-          { label: 'Spanish', value: 'es' },
-          { label: 'Japanese', value: 'ja' },
-          { label: 'French', value: 'fr' },
-          { label: 'German', value: 'de' },
-          { label: 'Italian', value: 'it' },
-          { label: 'Portuguese', value: 'pt' },
-          { label: 'Russian', value: 'ru' },
-          { label: 'Korean', value: 'ko' },
-          { label: 'Chinese Simplified', value: 'zhs' },
-          { label: 'Chinese Traditional', value: 'zht' },
-        ]"
+        :options="MAGIC_LANGUAGES.filter((lang) => lang.value !== 'en')"
         validation="required"
         validation-label="Language"
         :value="modelValue.language"
-        @input="updateValue('language', $event)"
-      />
+      >
+        <template #input="context">
+          <Dropdown
+            :model-value="context.value"
+            :options="MAGIC_LANGUAGES.filter((lang) => lang.value !== 'en')"
+            option-label="label"
+            option-value="value"
+            placeholder="Select a language"
+            class="w-full"
+            :class="{
+              'p-invalid': context.node.context?.state.valid === false,
+            }"
+            @update:model-value="(val: string) => context.node.input(val)"
+          />
+        </template>
+      </FormKit>
 
       <FormKit
         type="select"
         name="set"
         label="Card Set"
-        :options="[
-          { label: 'Modern Horizons 3', value: 'mh3' },
-          { label: 'Murders at Karlov Manor', value: 'mkm' },
-          { label: 'The Lost Caverns of Ixalan', value: 'lci' },
-          { label: 'Wilds of Eldraine', value: 'woe' },
-          { label: 'March of the Machine', value: 'mom' },
-          { label: 'Phyrexia: All Will Be One', value: 'one' },
-          { label: 'The Brothers\' War', value: 'bro' },
-          { label: 'Dominaria United', value: 'dmu' },
-        ]"
+        :options="MAGIC_SETS"
         validation="required"
         validation-label="Set"
         :value="modelValue.set"
-        @input="updateValue('set', $event)"
+      >
+        <template #input="context">
+          <Dropdown
+            :model-value="context.value"
+            :options="MAGIC_SETS"
+            option-label="label"
+            option-value="value"
+            placeholder="Select a set"
+            class="w-full"
+            :class="{
+              'p-invalid': context.node.context?.state.valid === false,
+            }"
+            @update:model-value="(val: string) => context.node.input(val)"
+          />
+        </template>
+      </FormKit>
+    </div>
+
+    <div class="mt-4">
+      <Button
+        type="submit"
+        label="Get Random Card"
+        icon="pi pi-refresh"
+        class="w-full md:w-auto"
       />
     </div>
   </FormKit>
 </template>
 
 <script setup lang="ts">
-interface CardFormData {
-  language: string;
-  set: string;
-}
+import { ref, watch } from "vue";
+import type { CardOptions } from "~/composables/useMagicCards";
+import { MAGIC_LANGUAGES, MAGIC_SETS } from "~/constants/magic";
 
 interface Props {
-  modelValue: CardFormData;
+  modelValue: CardOptions;
 }
 
-interface Emits {
-  (e: "update:modelValue", value: CardFormData): void;
-  (e: "submit", value: CardFormData): void;
-}
-
-const props = defineProps<Props>();
-const emit = defineEmits<Emits>();
-
-const updateValue = (key: keyof CardFormData, value: string) => {
-  emit("update:modelValue", {
-    ...props.modelValue,
-    [key]: value,
-  });
+type EmitType = {
+  (e: "update:modelValue" | "submit", value: CardOptions): void;
 };
 
-const handleSubmit = (formData: CardFormData) => {
+const props = defineProps<Props>();
+const emit = defineEmits<EmitType>();
+
+const formData = ref<CardOptions>({
+  language: props.modelValue.language,
+  set: props.modelValue.set,
+});
+
+watch(
+  formData,
+  (newValue) => {
+    emit("update:modelValue", newValue);
+  },
+  { deep: true }
+);
+
+const handleSubmit = (formData: CardOptions) => {
   emit("submit", formData);
 };
 </script>

--- a/apps/web/composables/useMagicCards.ts
+++ b/apps/web/composables/useMagicCards.ts
@@ -21,16 +21,15 @@ interface CardResponse {
   spanish: Card | null;
 }
 
-interface CardOptions {
+export interface CardOptions {
   language: string;
   set: string;
 }
 
-export const useMagicCards = () => {
-  const options = ref<CardOptions>({
-    language: "es",
-    set: "mh3",
-  });
+export const useMagicCards = (
+  initialOptions: CardOptions = { language: "es", set: "mh3" }
+) => {
+  const options = ref<CardOptions>(initialOptions);
 
   const getRandomCard = async (): Promise<CardResponse> => {
     try {
@@ -100,5 +99,6 @@ export const useMagicCards = () => {
     isFetching,
     error,
     updateOptions,
+    options: computed(() => options.value),
   };
 };

--- a/apps/web/composables/useMagicCards.ts
+++ b/apps/web/composables/useMagicCards.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/vue-query";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { ScryfallApiInstance } from "./scryfall";
 
 interface CardImage {
@@ -21,12 +21,22 @@ interface CardResponse {
   spanish: Card | null;
 }
 
+interface CardOptions {
+  language: string;
+  set: string;
+}
+
 export const useMagicCards = () => {
+  const options = ref<CardOptions>({
+    language: "es",
+    set: "mh3",
+  });
+
   const getRandomCard = async (): Promise<CardResponse> => {
     try {
-      // 1. Fetch a random MH3 card in English
+      // 1. Fetch a random card in English from the selected set
       const english = (await ScryfallApiInstance.getRandomCard(
-        "set:mh3"
+        `set:${options.value.set}`
       )) as Card;
 
       if (!english) {
@@ -35,41 +45,53 @@ export const useMagicCards = () => {
 
       console.log("Fetched English card:", english.name);
 
-      // 2. Fetch the Spanish version by name
+      // 2. Fetch the translated version by name
       const searchUrl = new URL("https://api.scryfall.com/cards/search");
-      searchUrl.searchParams.set("q", `lang:es name:"${english.name}"`);
+      searchUrl.searchParams.set(
+        "q",
+        `lang:${options.value.language} name:"${english.name}"`
+      );
 
       const searchRes = await fetch(searchUrl.toString()).then(async (res) => {
         if (!res.ok) {
-          throw new Error(`Failed to fetch Spanish card: ${res.statusText}`);
+          throw new Error(
+            `Failed to fetch ${options.value.language} card: ${res.statusText}`
+          );
         }
         return res.json();
       });
 
-      const spanish =
+      const translated =
         searchRes.data && searchRes.data.length > 0 ? searchRes.data[0] : null;
 
-      if (spanish) {
-        console.log("Fetched Spanish card:", spanish.name);
+      if (translated) {
+        console.log(`Fetched ${options.value.language} card:`, translated.name);
       } else {
-        console.warn("No Spanish translation found for:", english.name);
+        console.warn(
+          `No ${options.value.language} translation found for:`,
+          english.name
+        );
       }
 
-      return { english, spanish };
+      return { english, spanish: translated };
     } catch (error) {
       console.error("Error fetching cards:", error);
-      throw error; // Re-throw to let Vue Query handle it
+      throw error;
     }
   };
 
   const { data, refetch, isFetching, error } = useQuery({
-    queryKey: ["random-mh3-card"],
+    queryKey: ["random-card", options],
     queryFn: getRandomCard,
-    retry: 1, // Only retry once on failure
+    retry: 1,
   });
 
   const card = computed(() => data.value?.english);
   const cardEs = computed(() => data.value?.spanish);
+
+  const updateOptions = (newOptions: CardOptions) => {
+    options.value = newOptions;
+  };
 
   return {
     card,
@@ -77,5 +99,6 @@ export const useMagicCards = () => {
     refetch,
     isFetching,
     error,
+    updateOptions,
   };
 };

--- a/apps/web/constants/magic.ts
+++ b/apps/web/constants/magic.ts
@@ -1,0 +1,34 @@
+export interface MagicLanguage {
+  label: string;
+  value: string;
+}
+
+export interface MagicSet {
+  label: string;
+  value: string;
+}
+
+export const MAGIC_LANGUAGES: MagicLanguage[] = [
+  { label: "English", value: "en" },
+  { label: "Spanish", value: "es" },
+  { label: "Japanese", value: "ja" },
+  { label: "French", value: "fr" },
+  { label: "German", value: "de" },
+  { label: "Italian", value: "it" },
+  { label: "Portuguese", value: "pt" },
+  { label: "Russian", value: "ru" },
+  { label: "Korean", value: "ko" },
+  { label: "Chinese Simplified", value: "zhs" },
+  { label: "Chinese Traditional", value: "zht" },
+];
+
+export const MAGIC_SETS: MagicSet[] = [
+  { label: "Modern Horizons 3", value: "mh3" },
+  { label: "Murders at Karlov Manor", value: "mkm" },
+  { label: "The Lost Caverns of Ixalan", value: "lci" },
+  { label: "Wilds of Eldraine", value: "woe" },
+  { label: "March of the Machine", value: "mom" },
+  { label: "Phyrexia: All Will Be One", value: "one" },
+  { label: "The Brothers' War", value: "bro" },
+  { label: "Dominaria United", value: "dmu" },
+];

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -33,6 +33,7 @@ export default defineNuxtConfig({
     "@nuxt/ui",
     "@nuxt/image",
     "@nuxtjs/supabase",
+    "@formkit/nuxt",
     "shadcn-nuxt",
     "@primevue/nuxt-module",
     "@nuxtjs/i18n",
@@ -40,6 +41,10 @@ export default defineNuxtConfig({
   ],
   ui: {
     darkMode: false,
+  },
+  formkit: {
+    // Experimental support for auto loading (see note):
+    autoImport: true,
   },
   i18n: {
     defaultLocale: "en",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@archivos-templarios/types": "workspace:*",
+    "@formkit/nuxt": "^1.6.9",
     "@nuxt/fonts": "^0.11.2",
     "@nuxt/icon": "^1.12.0",
     "@nuxt/image": "^1.10.0",
@@ -46,10 +47,10 @@
     "@nuxt/devtools": "latest",
     "@nuxt/eslint": "^1.3.0",
     "@primevue/nuxt-module": "^4.3.4",
-    "eslint": "^9.26.0",
-    "typescript": "^5.8.2",
     "@tanstack/vue-query-devtools": "^5.76.0",
     "@vue/devtools-api": "7.7.6",
+    "eslint": "^9.26.0",
+    "typescript": "^5.8.2",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -1,144 +1,16 @@
 <template>
-  <div class="container mx-auto px-4 py-8">
-    <h1 class="text-3xl font-bold mb-8 text-gray-900 dark:text-white">
-      Magic: The Gathering Random Card Quiz
-    </h1>
-
-    <CardForm v-model="formData" @submit="handleFormSubmit" />
-
-    <div class="mb-6">
-      <button
-        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-        :disabled="isFetching"
-        @click="() => refetch()"
-      >
-        <span v-if="isFetching">Loading...</span>
-        <span v-else>Get Random Card</span>
-      </button>
-    </div>
-    <div class="mb-4 flex space-x-4">
-      <button
-        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-        @click="toggleEnglishOverlay"
-      >
-        {{ isEnglishCovered ? "Show English" : "Hide English" }}
-      </button>
-      <button
-        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-        @click="toggleSpanishOverlay"
-      >
-        {{ isSpanishCovered ? "Show Spanish" : "Hide Spanish" }}
-      </button>
-    </div>
-    <div
-      v-if="error"
-      class="max-w-[800px] mx-auto mb-4 p-4 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100 rounded-lg"
-    >
-      <p class="font-semibold">Error loading cards:</p>
-      <p>{{ error.message }}</p>
-      <button
-        class="mt-2 px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-        @click="() => refetch()"
-      >
-        Try Again
-      </button>
-    </div>
-    <div
-      v-if="card && cardEs"
-      class="grid md:grid-cols-2 gap-4 max-w-[800px] mx-auto"
-    >
-      <!-- English Card -->
-      <div
-        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
-      >
-        <CardImage :image-url="card.image_uris?.normal" :alt-text="card.name" />
-        <div
-          v-if="isEnglishCovered"
-          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
-        >
-          <span class="text-white text-xl">Covered</span>
-        </div>
-        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
-          {{ card.name }}
-        </h2>
-        <p class="text-gray-700 dark:text-gray-300 mb-2">
-          {{ card.type_line }}
-        </p>
-        <p class="text-gray-500 dark:text-gray-400">{{ card.oracle_text }}</p>
-      </div>
-      <!-- Spanish Card -->
-      <div
-        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
-      >
-        <CardImage
-          :image-url="cardEs.image_uris?.normal"
-          :alt-text="cardEs.name"
-        />
-        <div
-          v-if="isSpanishCovered"
-          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
-        >
-          <span class="text-white text-xl">Covered</span>
-        </div>
-        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
-          {{ cardEs.printed_name || cardEs.name }}
-        </h2>
-        <p class="text-gray-700 dark:text-gray-300 mb-2">
-          {{ cardEs.printed_type_line || cardEs.type_line }}
-        </p>
-        <p class="text-gray-500 dark:text-gray-400">
-          {{ cardEs.printed_text || cardEs.oracle_text }}
-        </p>
-      </div>
-    </div>
-    <div
-      v-else-if="isFetching"
-      class="text-center text-gray-500 dark:text-gray-400"
-    >
-      Loading...
-    </div>
-    <div v-else class="text-center text-gray-500 dark:text-gray-400">
-      Click the button to get a random card!
-    </div>
+  <div>
+    <NuxtPage />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
-import CardForm from "~/components/magic-cards/CardForm.vue";
-import CardImage from "~/components/magic-cards/CardImage.vue";
-import { useMagicCards, type CardOptions } from "~/composables/useMagicCards";
+import { onMounted } from "vue";
+import { useRouter } from "vue-router";
 
-const formData = ref<CardOptions>({
-  language: "es",
-  set: "mh3",
+const router = useRouter();
+
+onMounted(() => {
+  router.push("/magic-quiz/setup");
 });
-
-const { card, cardEs, refetch, isFetching, error, updateOptions } =
-  useMagicCards(formData.value);
-
-// Watch for form data changes and update the options
-watch(
-  formData,
-  (newValue) => {
-    updateOptions(newValue);
-  },
-  { deep: true }
-);
-
-const isEnglishCovered = ref(false);
-const isSpanishCovered = ref(false);
-
-const handleFormSubmit = (data: CardOptions) => {
-  formData.value = data;
-  refetch();
-};
-
-const toggleEnglishOverlay = () => {
-  isEnglishCovered.value = !isEnglishCovered.value;
-};
-
-const toggleSpanishOverlay = () => {
-  isSpanishCovered.value = !isSpanishCovered.value;
-};
 </script>

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -104,29 +104,33 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import CardForm from "~/components/magic-cards/CardForm.vue";
 import CardImage from "~/components/magic-cards/CardImage.vue";
-import { useMagicCards } from "~/composables/useMagicCards";
+import { useMagicCards, type CardOptions } from "~/composables/useMagicCards";
 
-interface FormData {
-  language: string;
-  set: string;
-}
-
-const formData = ref<FormData>({
+const formData = ref<CardOptions>({
   language: "es",
   set: "mh3",
 });
 
 const { card, cardEs, refetch, isFetching, error, updateOptions } =
-  useMagicCards();
+  useMagicCards(formData.value);
+
+// Watch for form data changes and update the options
+watch(
+  formData,
+  (newValue) => {
+    updateOptions(newValue);
+  },
+  { deep: true }
+);
 
 const isEnglishCovered = ref(false);
 const isSpanishCovered = ref(false);
 
-const handleFormSubmit = (data: FormData) => {
-  updateOptions(data);
+const handleFormSubmit = (data: CardOptions) => {
+  formData.value = data;
   refetch();
 };
 

--- a/apps/web/pages/magic-quiz.vue
+++ b/apps/web/pages/magic-quiz.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="container mx-auto px-4 py-8">
     <h1 class="text-3xl font-bold mb-8 text-gray-900 dark:text-white">
-      Magic: The Gathering Random MH3 Card (EN & ES)
+      Magic: The Gathering Random Card Quiz
     </h1>
+
+    <CardForm v-model="formData" @submit="handleFormSubmit" />
+
     <div class="mb-6">
       <button
         class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
@@ -102,13 +105,30 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import CardForm from "~/components/magic-cards/CardForm.vue";
 import CardImage from "~/components/magic-cards/CardImage.vue";
 import { useMagicCards } from "~/composables/useMagicCards";
 
-const { card, cardEs, refetch, isFetching, error } = useMagicCards();
+interface FormData {
+  language: string;
+  set: string;
+}
+
+const formData = ref<FormData>({
+  language: "es",
+  set: "mh3",
+});
+
+const { card, cardEs, refetch, isFetching, error, updateOptions } =
+  useMagicCards();
 
 const isEnglishCovered = ref(false);
 const isSpanishCovered = ref(false);
+
+const handleFormSubmit = (data: FormData) => {
+  updateOptions(data);
+  refetch();
+};
 
 const toggleEnglishOverlay = () => {
   isEnglishCovered.value = !isEnglishCovered.value;

--- a/apps/web/pages/magic-quiz/quiz.vue
+++ b/apps/web/pages/magic-quiz/quiz.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="flex justify-between items-center mb-8">
+      <h1 class="text-3xl font-bold text-gray-900 dark:text-white">
+        Magic: The Gathering Quiz
+      </h1>
+      <Button
+        label="Back to Setup"
+        icon="pi pi-arrow-left"
+        class="p-button-secondary"
+        @click="router.push('/magic-quiz/setup')"
+      />
+    </div>
+
+    <div class="mb-6">
+      <Button
+        label="Get Random Card"
+        icon="pi pi-refresh"
+        :loading="isFetching"
+        @click="() => refetch()"
+      />
+    </div>
+
+    <div class="mb-4 flex space-x-4">
+      <Button
+        :label="isEnglishCovered ? 'Show English' : 'Hide English'"
+        icon="pi pi-eye"
+        @click="store.toggleEnglishOverlay()"
+      />
+      <Button
+        :label="isSpanishCovered ? 'Show Spanish' : 'Hide Spanish'"
+        icon="pi pi-eye"
+        @click="store.toggleSpanishOverlay()"
+      />
+    </div>
+
+    <div
+      v-if="error"
+      class="max-w-[800px] mx-auto mb-4 p-4 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100 rounded-lg"
+    >
+      <p class="font-semibold">Error loading cards:</p>
+      <p>{{ error.message }}</p>
+      <Button
+        label="Try Again"
+        icon="pi pi-refresh"
+        class="p-button-danger mt-2"
+        @click="() => refetch()"
+      />
+    </div>
+
+    <div
+      v-if="card && cardEs"
+      class="grid md:grid-cols-2 gap-4 max-w-[800px] mx-auto"
+    >
+      <!-- English Card -->
+      <div
+        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
+      >
+        <CardImage :image-url="card.image_uris?.normal" :alt-text="card.name" />
+        <div
+          v-if="isEnglishCovered"
+          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+        >
+          <span class="text-white text-xl">Covered</span>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
+          {{ card.name }}
+        </h2>
+        <p class="text-gray-700 dark:text-gray-300 mb-2">
+          {{ card.type_line }}
+        </p>
+        <p class="text-gray-500 dark:text-gray-400">{{ card.oracle_text }}</p>
+      </div>
+
+      <!-- Spanish Card -->
+      <div
+        class="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 relative"
+      >
+        <CardImage
+          :image-url="cardEs.image_uris?.normal"
+          :alt-text="cardEs.name"
+        />
+        <div
+          v-if="isSpanishCovered"
+          class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+        >
+          <span class="text-white text-xl">Covered</span>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
+          {{ cardEs.printed_name || cardEs.name }}
+        </h2>
+        <p class="text-gray-700 dark:text-gray-300 mb-2">
+          {{ cardEs.printed_type_line || cardEs.type_line }}
+        </p>
+        <p class="text-gray-500 dark:text-gray-400">
+          {{ cardEs.printed_text || cardEs.oracle_text }}
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-else-if="isFetching"
+      class="text-center text-gray-500 dark:text-gray-400"
+    >
+      Loading...
+    </div>
+    <div v-else class="text-center text-gray-500 dark:text-gray-400">
+      Click the button to get a random card!
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { useRouter } from "vue-router";
+import CardImage from "~/components/magic-cards/CardImage.vue";
+import { useMagicCards } from "~/composables/useMagicCards";
+import { useMagicQuizStore } from "~/stores/magicQuiz";
+
+const router = useRouter();
+const store = useMagicQuizStore();
+const { formData, isEnglishCovered, isSpanishCovered } = storeToRefs(store);
+
+const { card, cardEs, refetch, isFetching, error } = useMagicCards(
+  formData.value
+);
+</script>

--- a/apps/web/pages/magic-quiz/setup.vue
+++ b/apps/web/pages/magic-quiz/setup.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold mb-8 text-gray-900 dark:text-white">
+      Magic: The Gathering Quiz Setup
+    </h1>
+
+    <CardForm v-model="formData" @submit="handleFormSubmit" />
+
+    <div class="mt-8">
+      <Button
+        label="Start Quiz"
+        icon="pi pi-play"
+        class="w-full md:w-auto"
+        @click="navigateToQuiz"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import CardForm from "~/components/magic-cards/CardForm.vue";
+import type { CardOptions } from "~/composables/useMagicCards";
+import { useMagicQuizStore } from "~/stores/magicQuiz";
+
+const router = useRouter();
+const store = useMagicQuizStore();
+
+const formData = ref<CardOptions>({
+  language: store.formData.language,
+  set: store.formData.set,
+});
+
+const handleFormSubmit = (data: CardOptions) => {
+  formData.value = data;
+  store.updateFormData(data);
+};
+
+const navigateToQuiz = () => {
+  router.push("/magic-quiz/quiz");
+};
+</script>

--- a/apps/web/stores/magicQuiz.ts
+++ b/apps/web/stores/magicQuiz.ts
@@ -1,0 +1,31 @@
+import { defineStore } from "pinia";
+import type { CardOptions } from "~/composables/useMagicCards";
+
+interface MagicQuizState {
+  formData: CardOptions;
+  isEnglishCovered: boolean;
+  isSpanishCovered: boolean;
+}
+
+export const useMagicQuizStore = defineStore("magicQuiz", {
+  state: (): MagicQuizState => ({
+    formData: {
+      language: "es",
+      set: "mh3",
+    },
+    isEnglishCovered: false,
+    isSpanishCovered: false,
+  }),
+
+  actions: {
+    updateFormData(data: CardOptions) {
+      this.formData = data;
+    },
+    toggleEnglishOverlay() {
+      this.isEnglishCovered = !this.isEnglishCovered;
+    },
+    toggleSpanishOverlay() {
+      this.isSpanishCovered = !this.isSpanishCovered;
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@archivos-templarios/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@formkit/nuxt':
+        specifier: ^1.6.9
+        version: 1.6.9(esbuild@0.25.4)(magicast@0.3.5)(rollup@4.40.2)(tailwindcss@4.1.5)(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
       '@nuxt/fonts':
         specifier: ^0.11.2
         version: 0.11.2(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.6.1)(magicast@0.3.5)(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
@@ -554,6 +557,52 @@ packages:
 
   '@floating-ui/vue@1.1.6':
     resolution: {integrity: sha512-XFlUzGHGv12zbgHNk5FN2mUB7ROul3oG2ENdTpWdE+qMFxyNxWSRmsoyhiEnpmabNm6WnUvR1OvJfUfN4ojC1A==}
+
+  '@formkit/core@1.6.9':
+    resolution: {integrity: sha512-Zb5OkYKMf7Rp1pd4iUMv0TJQvfgl1PdKtRRQoGiTA0XIFLB/7tcRMr1wc5isA2JS+hllfxMTh3RWF8N+64fTMg==}
+
+  '@formkit/dev@1.6.9':
+    resolution: {integrity: sha512-4ueBpZAOiKr8/LZnq3mNePCX4ZB1j1JuJscBEwugWMnDeDwCNo5XWBrng1ER/LlitTRQ3mtEBNy2Qpm0yAHlwA==}
+
+  '@formkit/i18n@1.6.9':
+    resolution: {integrity: sha512-8NA5bALlspCBEwInuZVgBqgQr0lDfproZdmbs2LciQpGi2B15u74JCjAkEwaKlMs+qgf/ds3QcIgUv2ztyyVEA==}
+
+  '@formkit/inputs@1.6.9':
+    resolution: {integrity: sha512-k9gjV1e5F87NxSnu13JtKb30XYt6ndx2KGHZG8Xz0etoP75yJlMaeROHHPvlxdy2gZM6qH7Ex4it51W74Wh2Eg==}
+
+  '@formkit/nuxt@1.6.9':
+    resolution: {integrity: sha512-G2J20hg1XVvP9l0lcclqeH6xIzVbQ1V1XS0LmVTJ3xBXL2QhXV6EUwkN6FGMjjtBJdtK1SMRmTXDc9rcLJgS1A==}
+
+  '@formkit/observer@1.6.9':
+    resolution: {integrity: sha512-p3MCmzp6jwzXIuV3gI9uTJTJl+sN5689C7qf7gdrS8jb1fbX1snKiTyWA8FXOrBXu+ne5z/sA/yBWqYFTSLy8A==}
+
+  '@formkit/rules@1.6.9':
+    resolution: {integrity: sha512-5Vu3JACKyws1kw02qF+024WkS7L9kYZ0lmdSpsaTqg5Wf7+InsxWXFYaG6vCzqIh4Lk9NeffIzq/xyGpGxf5uQ==}
+
+  '@formkit/themes@1.6.9':
+    resolution: {integrity: sha512-/UD+MehQEdcCEadt73eIBGGAMEK8ODN0yq9r9299WvQxIELCOP2MbcxuWCV/g2Vd15Xhl8YFdn4KCzQi4X7QXA==}
+    peerDependencies:
+      tailwindcss: ^3.2.0
+      unocss: 0.x.x
+      windicss: ^3.0.0
+    peerDependenciesMeta:
+      tailwindcss:
+        optional: true
+      unocss:
+        optional: true
+      windicss:
+        optional: true
+
+  '@formkit/utils@1.6.9':
+    resolution: {integrity: sha512-vSFhB/Sm/A+SdwKdBi4WhJcdbePqSYRaB878Ol9HL8roTmmmgQpThvkv6EjLM6aRRP27Il5rS8XtIAIeh8vdTA==}
+
+  '@formkit/validation@1.6.9':
+    resolution: {integrity: sha512-9PGwN0ZDJt3hsrMyaL8KTG3diSQDik1OGogVG6/nFcZhWUycpeamFfXZSQ5pfzmwnvrTHsvyT0FtKitUnWWuPA==}
+
+  '@formkit/vue@1.6.9':
+    resolution: {integrity: sha512-WrjAtEsKnFJzxQuATWsWKMpTAyJE15PUmRh9hwEAqgTDy2yMog1gxqxfZv3rEAdIdgXNp08tWmRVnQgDIF3vAQ==}
+    peerDependencies:
+      vue: ^3.4.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5421,6 +5470,23 @@ packages:
       '@vueuse/core':
         optional: true
 
+  unplugin-formkit@0.2.13:
+    resolution: {integrity: sha512-qNHz7/0QDO0uVD5MoUZz49CI7q8cHM24RQDwbs5NfRJ6EiyZ1gBmWq9ta3QHR2nD7xacXV+yzmfDbnwlNpkzsg==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   unplugin-utils@0.2.4:
     resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
     engines: {node: '>=18.12.0'}
@@ -6343,6 +6409,89 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@formkit/core@1.6.9':
+    dependencies:
+      '@formkit/utils': 1.6.9
+
+  '@formkit/dev@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/utils': 1.6.9
+
+  '@formkit/i18n@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/utils': 1.6.9
+      '@formkit/validation': 1.6.9
+
+  '@formkit/inputs@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/utils': 1.6.9
+
+  '@formkit/nuxt@1.6.9(esbuild@0.25.4)(magicast@0.3.5)(rollup@4.40.2)(tailwindcss@4.1.5)(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/i18n': 1.6.9
+      '@formkit/vue': 1.6.9(tailwindcss@4.1.5)(vue@3.5.13(typescript@5.8.3))
+      '@nuxt/kit': 3.17.3(magicast@0.3.5)
+      chokidar: 3.6.0
+      pathe: 1.1.2
+      unplugin: 1.16.1
+      unplugin-formkit: 0.2.13(esbuild@0.25.4)(rollup@4.40.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+    transitivePeerDependencies:
+      - esbuild
+      - magicast
+      - rollup
+      - tailwindcss
+      - unocss
+      - vite
+      - vue
+      - webpack
+      - windicss
+
+  '@formkit/observer@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/utils': 1.6.9
+
+  '@formkit/rules@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/utils': 1.6.9
+      '@formkit/validation': 1.6.9
+
+  '@formkit/themes@1.6.9(tailwindcss@4.1.5)':
+    dependencies:
+      '@formkit/core': 1.6.9
+    optionalDependencies:
+      tailwindcss: 4.1.5
+
+  '@formkit/utils@1.6.9': {}
+
+  '@formkit/validation@1.6.9':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/observer': 1.6.9
+      '@formkit/utils': 1.6.9
+
+  '@formkit/vue@1.6.9(tailwindcss@4.1.5)(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@formkit/core': 1.6.9
+      '@formkit/dev': 1.6.9
+      '@formkit/i18n': 1.6.9
+      '@formkit/inputs': 1.6.9
+      '@formkit/observer': 1.6.9
+      '@formkit/rules': 1.6.9
+      '@formkit/themes': 1.6.9(tailwindcss@4.1.5)
+      '@formkit/utils': 1.6.9
+      '@formkit/validation': 1.6.9
+      vue: 3.5.13(typescript@5.8.3)
+    transitivePeerDependencies:
+      - tailwindcss
+      - unocss
+      - windicss
 
   '@humanfs/core@0.19.1': {}
 
@@ -12143,6 +12292,15 @@ snapshots:
     optionalDependencies:
       '@nuxt/kit': 3.17.2(magicast@0.3.5)
       '@vueuse/core': 13.2.0(vue@3.5.13(typescript@5.8.3))
+
+  unplugin-formkit@0.2.13(esbuild@0.25.4)(rollup@4.40.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)):
+    dependencies:
+      pathe: 1.1.2
+      unplugin: 1.16.1
+    optionalDependencies:
+      esbuild: 0.25.4
+      rollup: 4.40.2
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
 
   unplugin-utils@0.2.4:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a form allowing users to select card language and set before retrieving a random Magic: The Gathering card.
  - Users can now choose from multiple languages (excluding English) and various card sets.
- **Enhancements**
  - The random card quiz page now reflects user-selected language and set in its results.
  - Improved page title for clarity.
- **Dependencies**
  - Integrated FormKit for enhanced form management and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->